### PR TITLE
Fix indent that resulted in undefined soil spectra

### DIFF
--- a/prosail/sail_model.py
+++ b/prosail/sail_model.py
@@ -132,10 +132,11 @@ def run_prosail(
                 "If rsoil0 isn't define, then rsoil and psoil"
                 " need to be defined!"
             )
-    else:
-        rsoil0 = rsoil * (
-            psoil * soil_spectrum1 + (1.0 - psoil) * soil_spectrum2
-        )
+        else:
+
+            rsoil0 = rsoil * (
+                psoil * soil_spectrum1 + (1.0 - psoil) * soil_spectrum2
+            )
 
     wv, refl, trans = run_prospect(
         n,
@@ -313,10 +314,10 @@ def run_sail(
                 "If rsoil0 isn't define, then rsoil and psoil"
                 " need to be defined!"
             )
-    else:
-        rsoil0 = rsoil * (
-            psoil * soil_spectrum1 + (1.0 - psoil) * soil_spectrum2
-        )
+        else:
+            rsoil0 = rsoil * (
+                psoil * soil_spectrum1 + (1.0 - psoil) * soil_spectrum2
+            )
 
     [
         tss,


### PR DESCRIPTION
The soil spectra is now defined with psoil and rsoil. Before, it just skipped over the calculation of the soil reflectance if rsoil0 was not provided by the user.